### PR TITLE
Show debtor summary and hide main window

### DIFF
--- a/ViewModels/AddDebtorViewModel.cs
+++ b/ViewModels/AddDebtorViewModel.cs
@@ -102,6 +102,13 @@ namespace bankrupt_piterjust.ViewModels
             set { _email = value; OnPropertyChanged(nameof(Email)); }
         }
 
+        private DateTime _birthDate = DateTime.Now.AddYears(-18);
+        public DateTime BirthDate
+        {
+            get => _birthDate;
+            set { _birthDate = value; OnPropertyChanged(nameof(BirthDate)); }
+        }
+
         private string _fullName;
         public string FullName
         {

--- a/ViewModels/EditDebtorViewModel.cs
+++ b/ViewModels/EditDebtorViewModel.cs
@@ -111,6 +111,13 @@ namespace bankrupt_piterjust.ViewModels
             set { _email = value; OnPropertyChanged(nameof(Email)); }
         }
 
+        private DateTime _birthDate = DateTime.Now.AddYears(-18);
+        public DateTime BirthDate
+        {
+            get => _birthDate;
+            set { _birthDate = value; OnPropertyChanged(nameof(BirthDate)); }
+        }
+
         private string _fullName = string.Empty;
         public string FullName
         {

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -652,13 +652,17 @@ namespace bankrupt_piterjust.ViewModels
 
         private void AddDebtor()
         {
+            var mainWindow = Application.Current?.MainWindow;
             var addWindow = new DebtorWindow
             {
-                // Устанавливаем владельца, чтобы окно появилось по центру главного
-                Owner = Application.Current?.MainWindow
+                Owner = mainWindow
             };
 
-            if (addWindow.ShowDialog() == true && addWindow.NewDebtor != null)
+            mainWindow?.Hide();
+            bool? result = addWindow.ShowDialog();
+            mainWindow?.Show();
+
+            if (result == true && addWindow.NewDebtor != null)
             {
                 var newDebtor = addWindow.NewDebtor;
                 _allDebtors.Add(newDebtor);
@@ -679,11 +683,17 @@ namespace bankrupt_piterjust.ViewModels
             if (SelectedDebtor?.PersonId == null)
                 return;
 
+            var mainWindow = Application.Current?.MainWindow;
             var editWindow = new DebtorWindow(SelectedDebtor.PersonId.Value)
             {
-                Owner = Application.Current?.MainWindow
+                Owner = mainWindow
             };
-            if (editWindow.ShowDialog() == true)
+
+            mainWindow?.Hide();
+            bool? result = editWindow.ShowDialog();
+            mainWindow?.Show();
+
+            if (result == true)
             {
                 _ = LoadDataAsync();
             }

--- a/Views/DebtorWindow.xaml
+++ b/Views/DebtorWindow.xaml
@@ -253,6 +253,20 @@
             <!-- Bottom action area -->
         </Grid.RowDefinitions>
 
+        <!-- Summary Header -->
+        <StackPanel Grid.Row="0" Margin="25,20" >
+            <TextBlock Text="{Binding FullName}"
+                       FontSize="18"
+                       FontWeight="SemiBold"/>
+            <WrapPanel Margin="0,5,0,0">
+                <TextBlock Text="{Binding RegistrationAddress.Region, StringFormat=Регион: {0}}"
+                           Margin="0,0,20,0"/>
+                <TextBlock Text="{Binding BirthDate, StringFormat=Дата рождения: {0:dd.MM.yyyy}}"
+                           Margin="0,0,20,0"/>
+                <TextBlock Text="{Binding ContractDate, StringFormat=Договор от: {0:dd.MM.yyyy}}"/>
+            </WrapPanel>
+        </StackPanel>
+
         
 
         <!-- Main Content -->


### PR DESCRIPTION
## Summary
- hide `MainWindow` while debtor window is open
- show debtor info summary above the tabs
- track debtor birth date property in Add and Edit view models

## Testing
- `dotnet build bankrupt-piterjust.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688bd79856648325bebe9cfb3748cdfe